### PR TITLE
feat: Add GitHub Actions workflow for Maven release and Docker image upload

### DIFF
--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -1,0 +1,125 @@
+---
+    # This GitHub Actions workflow is designed to be triggered when a release is marked as a full release.
+    # The workflow performs the following tasks:
+    # - Extract Release Version: Extracts the tag name and removes the leading 'v' character to get the release version.
+    # - Update pom.xml: Updates the version in the pom.xml file using the extracted release version.
+    # - Publish to Maven: Publishes the artifact to the Maven repository using the updated pom.xml.
+
+    name: Release And Upload to Maven Central
+
+    on:
+      workflow_dispatch:
+        inputs:
+          version:
+            required: true
+            default: '1.0.0'
+            type: string
+            description: 'Release version (e.g., 2025.1-1.0.0)'
+          java_version:
+            required: false
+            type: string
+            default: "21"
+            description: 'Java version (e.g., 21)'
+          upload-artifact:
+            required: false
+            type: boolean
+            default: true
+            description: 'Upload artifact'
+
+    jobs:
+      check-tag:
+        runs-on: ubuntu-latest
+        steps:
+          - name: Input parameters
+            run: |
+              echo "Version: ${{ github.event.inputs.version }}" >> $GITHUB_STEP_SUMMARY
+              echo "Java version: ${{ github.event.inputs.java_version }}" >> $GITHUB_STEP_SUMMARY
+
+          - name: Checkout code
+            uses: actions/checkout@v4
+
+          - name: Check if tag exists
+            id: check_tag
+            uses: netcracker/qubership-workflow-hub/actions/tag-checker@main
+            with:
+              tag: 'v${{ github.event.inputs.version }}'
+            env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          - name: Output result
+            run: |
+              echo "Tag exists: ${{ steps.check_tag.outputs.exists }}"
+              echo "Tag name: v${{ github.event.inputs.version }}"
+
+          - name: Fail if tag exists
+            if: steps.check_tag.outputs.exists == 'true'
+            run: |
+              echo "Tag already exists: v${{ github.event.inputs.version }}" >> $GITHUB_STEP_SUMMARY
+              echo "Tag already exists: v${{ github.event.inputs.version }}"
+              exit 1
+
+      update-pom-version:
+        runs-on: ubuntu-latest
+        outputs:
+          artifact_id: ${{ steps.config.outputs.artifact_id }}
+        steps:
+          - name: Checkout code
+            uses: actions/checkout@v4
+
+          - name: Update pom.xml
+            id: config
+            uses: nookyo/qubership-workflow-hub/actions/pom-updater@main
+            with:
+              new_value: ${{ github.event.inputs.version }}
+              file_path: '{"default": "pom.xml", "consul": "./qubership-consul/pom.xml"}'
+
+          - name: Commit Changes
+            uses: nookyo/qubership-workflow-hub/actions/commit-and-push@main
+            with:
+              commit_message: "Update pom.xml version to ${{ github.event.inputs.version }}"
+
+      mvn-build:
+        needs: [update-pom-version]
+        uses: nookyo/qubership-workflow-hub/.github/workflows/maven-publish.yml@main
+        with:
+          maven_command: "--batch-mode package"
+          java_version: ${{ github.event.inputs.java_version }}
+          version: ${{ github.event.inputs.version }}
+          upload-artifact: true
+          artifact-id: ${{ needs.update-pom-version.outputs.artifact_id }}
+        secrets:
+          maven_username: ${{ secrets.MAVEN_USER }}
+          maven_password: ${{ secrets.MAVEN_PASSWORD }}
+          maven_gpg_passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          maven_gpg_private_key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+
+      tests:
+        needs: [mvn-build]
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout code
+            uses: actions/checkout@v4
+
+          - name: Run tests
+            run: echo "Running tests here"
+
+      tag:
+        needs: [tests]
+        uses: nookyo/qubership-workflow-hub/.github/workflows/tag-creator.yml@main
+        with:
+          tag-name: ${{ github.event.inputs.version }}
+
+      docker-build-publish:
+        needs: [update-pom-version, tag]
+        uses: nookyo/qubership-workflow-hub/.github/workflows/docker-publish.yml@main
+        with:
+          ref: ${{ github.event.inputs.version }}
+          artifact-id: ${{ needs.update-pom-version.outputs.artifact_id }}
+          dry-run: false
+
+      github-release:
+        needs: [tag]
+        uses: nookyo/qubership-workflow-hub/.github/workflows/release-drafter.yml@main
+        with:
+          version: ${{ github.event.inputs.version }}
+          publish: false

--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -5,7 +5,7 @@
     # - Update pom.xml: Updates the version in the pom.xml file using the extracted release version.
     # - Publish to Maven: Publishes the artifact to the Maven repository using the updated pom.xml.
 
-    name: Release And Upload to Maven Central
+    name: Release And Upload Docker Image
 
     on:
       workflow_dispatch:

--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -20,11 +20,11 @@
             type: string
             default: "21"
             description: 'Java version (e.g., 21)'
-          upload-artifact:
+          dry-run:
             required: false
             type: boolean
-            default: true
-            description: 'Upload artifact'
+            default: false
+            description: 'Dry run'
 
     jobs:
       check-tag:
@@ -115,7 +115,7 @@
         with:
           ref: ${{ github.event.inputs.version }}
           artifact-id: ${{ needs.update-pom-version.outputs.artifact_id }}
-          dry-run: false
+          dry-run: ${{ github.event.inputs.dry-run }}
 
       github-release:
         needs: [tag]

--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -116,7 +116,7 @@
         with:
           ref: ${{ github.event.inputs.version }}
           artifact-id: ${{ needs.update-pom-version.outputs.artifact_id }}
-          dry-run: ${{ github.event.inputs.dry-run }}
+          dry-run: true
 
       github-release:
         needs: [tag]

--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -60,6 +60,7 @@
 
       update-pom-version:
         runs-on: ubuntu-latest
+        needs: [check-tag]
         outputs:
           artifact_id: ${{ steps.config.outputs.artifact_id }}
         steps:

--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -5,7 +5,7 @@
     # - Update pom.xml: Updates the version in the pom.xml file using the extracted release version.
     # - Publish to Maven: Publishes the artifact to the Maven repository using the updated pom.xml.
 
-    name: Release And Upload Docker Image
+    name: Release And Upload Docker Images
 
     on:
       workflow_dispatch:
@@ -69,19 +69,19 @@
 
           - name: Update pom.xml
             id: config
-            uses: nookyo/qubership-workflow-hub/actions/pom-updater@main
+            uses: netcracker/qubership-workflow-hub/actions/pom-updater@main
             with:
               new_value: ${{ github.event.inputs.version }}
               file_path: '{"default": "pom.xml"}'
 
           - name: Commit Changes
-            uses: nookyo/qubership-workflow-hub/actions/commit-and-push@main
+            uses: netcracker/qubership-workflow-hub/actions/commit-and-push@main
             with:
               commit_message: "Update pom.xml version to ${{ github.event.inputs.version }}"
 
       mvn-build:
         needs: [update-pom-version]
-        uses: nookyo/qubership-workflow-hub/.github/workflows/maven-publish.yml@main
+        uses: netcracker/qubership-workflow-hub/.github/workflows/maven-publish.yml@main
         with:
           maven_command: "--batch-mode package"
           java_version: ${{ github.event.inputs.java_version }}
@@ -106,13 +106,13 @@
 
       tag:
         needs: [tests]
-        uses: nookyo/qubership-workflow-hub/.github/workflows/tag-creator.yml@main
+        uses: netcracker/qubership-workflow-hub/.github/workflows/tag-creator.yml@main
         with:
           tag-name: ${{ github.event.inputs.version }}
 
       docker-build-publish:
         needs: [update-pom-version, tag]
-        uses: nookyo/qubership-workflow-hub/.github/workflows/docker-publish.yml@main
+        uses: netcracker/qubership-workflow-hub/.github/workflows/docker-publish.yml@main
         with:
           ref: ${{ github.event.inputs.version }}
           artifact-id: ${{ needs.update-pom-version.outputs.artifact_id }}
@@ -120,7 +120,7 @@
 
       github-release:
         needs: [tag]
-        uses: nookyo/qubership-workflow-hub/.github/workflows/release-drafter.yml@main
+        uses: netcracker/qubership-workflow-hub/.github/workflows/release-drafter.yml@main
         with:
           version: ${{ github.event.inputs.version }}
           publish: false

--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -116,7 +116,7 @@
         with:
           ref: ${{ github.event.inputs.version }}
           artifact-id: ${{ needs.update-pom-version.outputs.artifact_id }}
-          dry-run: true
+          dry-run: ${{ inputs.dry-run }}
 
       github-release:
         needs: [tag]

--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -23,7 +23,7 @@
           dry-run:
             required: false
             type: boolean
-            default: false
+            default: true
             description: 'Dry run'
 
     jobs:

--- a/.github/workflows/maven-release.yaml
+++ b/.github/workflows/maven-release.yaml
@@ -72,7 +72,7 @@
             uses: nookyo/qubership-workflow-hub/actions/pom-updater@main
             with:
               new_value: ${{ github.event.inputs.version }}
-              file_path: '{"default": "pom.xml", "consul": "./qubership-consul/pom.xml"}'
+              file_path: '{"default": "pom.xml"}'
 
           - name: Commit Changes
             uses: nookyo/qubership-workflow-hub/actions/commit-and-push@main

--- a/nifi-registry-db-util/pom.xml
+++ b/nifi-registry-db-util/pom.xml
@@ -42,7 +42,7 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <phase>install</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>copy-dependencies</goal>
                         </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </parent>
 
     <properties>
-        <revision>1.0.1</revision>
+        <revision>1.0.0</revision>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     </parent>
 
     <properties>
-        <revision>1.0.0</revision>
+        <revision>1.0.1</revision>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Introduce a GitHub Actions workflow to streamline the Maven release process and Docker image publishing. The workflow includes a dry-run option, updates the POM version, and ensures proper tagging and artifact management. Additionally, fix the execution phase of the maven-dependency-plugin in the POM file.