### PR TITLE
feat(ci): add PR auto-assignment workflow and configuration

### DIFF
--- a/.github/pr-assigner-config.yml
+++ b/.github/pr-assigner-config.yml
@@ -1,0 +1,3 @@
+assignees:
+  - dmitry618
+count: 1

--- a/.github/workflows/pr-assigner.yml
+++ b/.github/workflows/pr-assigner.yml
@@ -1,0 +1,15 @@
+name: PR Auto-Assignment
+run-name: "Assigning reviewers for PR #${{ github.event.pull_request.number }}"
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+    branches:
+      - main
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  pr-auto-assign:
+    uses: netcracker/qubership-workflow-hub/.github/workflows/re-pr-assigner.yml@main


### PR DESCRIPTION
Introduce a workflow for automatically assigning reviewers to pull requests targeting the main branch. This configuration streamlines the review process by ensuring designated reviewers are assigned upon PR creation or updates.