### PR TITLE
fix: revert incorrect shellcheck fixes

### DIFF
--- a/.github/collections/NiFi_Registry_Policy_API_Tests.postman_collection.json
+++ b/.github/collections/NiFi_Registry_Policy_API_Tests.postman_collection.json
@@ -21,7 +21,7 @@
                                     "pm.test(\"Response is JSON and contains 1 user\", function () {\r",
                                     "    var jsonData = pm.response.json();\r",
                                     "    pm.expect(jsonData.length).to.eql(1);\r",
-                                    "    pm.expect(jsonData[0].identity).to.eql(\"CN=admin, OU=NIFI\");\r",
+                                    "    pm.expect(jsonData[0].identity).to.eql(\"admin\");\r",
                                     "    pm.environment.set(\"registry.default.admin.id\", jsonData[0].identifier);\r",
                                     "});"
                                 ],
@@ -313,7 +313,7 @@
                                     "});\r",
                                     "pm.test(\"Response is JSON and contains user data\", function () {\r",
                                     "    var jsonData = pm.response.json();\r",
-                                    "    pm.expect(jsonData.identity).to.eql(\"CN=admin, OU=NIFI\");\r",
+                                    "    pm.expect(jsonData.identity).to.eql(\"admin\");\r",
                                     "});"
                                 ],
                                 "type": "text/javascript"
@@ -944,7 +944,7 @@
                                     "pm.test(\"Response is JSON and contains 1 user\", function () {\r",
                                     "    var jsonData = pm.response.json();\r",
                                     "    pm.expect(jsonData.users.length).to.eql(1);\r",
-                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"CN=admin, OU=NIFI\");\r",
+                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"admin\");\r",
                                     "    pm.environment.set(\"registry.read.proxy.id\", jsonData.identifier);\r",
                                     "    pm.environment.set(\"registry.read.proxy.version\", jsonData.revision.version);\r",
                                     "});"
@@ -984,7 +984,7 @@
                                     "pm.test(\"Response is JSON and contains 1 user\", function () {\r",
                                     "    var jsonData = pm.response.json();\r",
                                     "    pm.expect(jsonData.users.length).to.eql(1);\r",
-                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"CN=admin, OU=NIFI\");\r",
+                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"admin\");\r",
                                     "    pm.environment.set(\"registry.write.proxy.id\", jsonData.identifier);\r",
                                     "    pm.environment.set(\"registry.write.proxy.version\", jsonData.revision.version);\r",
                                     "});"
@@ -1114,7 +1114,7 @@
                                     "pm.test(\"Response is JSON and contains 1 user\", function () {\r",
                                     "    var jsonData = pm.response.json();\r",
                                     "    pm.expect(jsonData.users.length).to.eql(1);\r",
-                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"CN=admin, OU=NIFI\");\r",
+                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"admin\");\r",
                                     "    pm.environment.set(\"registry.read.buckets.id\", jsonData.identifier);\r",
                                     "    pm.environment.set(\"registry.read.buckets.version\", jsonData.revision.version);\r",
                                     "});"
@@ -1154,7 +1154,7 @@
                                     "pm.test(\"Response is JSON and contains 1 user\", function () {\r",
                                     "    var jsonData = pm.response.json();\r",
                                     "    pm.expect(jsonData.users.length).to.eql(1);\r",
-                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"CN=admin, OU=NIFI\");\r",
+                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"admin\");\r",
                                     "    pm.environment.set(\"registry.write.buckets.id\", jsonData.identifier);\r",
                                     "    pm.environment.set(\"registry.write.buckets.version\", jsonData.revision.version);\r",
                                     "});"
@@ -1194,7 +1194,7 @@
                                     "pm.test(\"Response is JSON and contains 1 user\", function () {\r",
                                     "    var jsonData = pm.response.json();\r",
                                     "    pm.expect(jsonData.users.length).to.eql(1);\r",
-                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"CN=admin, OU=NIFI\");\r",
+                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"admin\");\r",
                                     "    pm.environment.set(\"registry.delete.buckets.id\", jsonData.identifier);\r",
                                     "    pm.environment.set(\"registry.delete.buckets.version\", jsonData.revision.version);\r",
                                     "});"
@@ -1370,7 +1370,7 @@
                                     "    var jsonData = pm.response.json();\r",
                                     "    pm.expect(jsonData.userGroups.length).to.eql(1);\r",
                                     "    pm.expect(jsonData.users.length).to.eql(1);\r",
-                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"CN=admin, OU=NIFI\");\r",
+                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"admin\");\r",
                                     "});"
                                 ],
                                 "type": "text/javascript"
@@ -1453,7 +1453,7 @@
                                     "    var jsonData = pm.response.json();\r",
                                     "    pm.expect(jsonData.userGroups.length).to.eql(1);\r",
                                     "    pm.expect(jsonData.users.length).to.eql(1);\r",
-                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"CN=admin, OU=NIFI\");\r",
+                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"admin\");\r",
                                     "    pm.environment.set(\"registry.delete.newbucket.id\", jsonData.identifier);\r",
                                     "    pm.environment.set(\"registry.delete.newbucket.version\", jsonData.revision.version);\r",
                                     "});"
@@ -1501,7 +1501,7 @@
                                     "    var jsonData = pm.response.json();\r",
                                     "    pm.expect(jsonData.userGroups.length).to.eql(1);\r",
                                     "    pm.expect(jsonData.users.length).to.eql(1);\r",
-                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"CN=admin, OU=NIFI\");\r",
+                                    "    pm.expect(jsonData.users[0].identity).to.eql(\"admin\");\r",
                                     "});"
                                 ],
                                 "type": "text/javascript"

--- a/.github/docker/oidc/docker-compose.yaml
+++ b/.github/docker/oidc/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       - TRUSTSTORE_PATH=/tmp/tls-certs/truststore.p12
       - TRUSTSTORE_TYPE=PKCS12
       - TRUSTSTORE_PASSWORD=${TRUSTSTORE_PASSWORD}
-      - INITIAL_ADMIN_IDENTITY=CN=admin, OU=NIFI
+      - INITIAL_ADMIN_IDENTITY=admin
       - NIFI_REG_USE_PGDB=true
       - NIFI_REG_DB_URL=jdbc:postgresql://postgresql:5432/postgres
       - NIFI_REG_DB_USERNAME=postgres

--- a/.github/docker/tls-db-std/docker-compose.yaml
+++ b/.github/docker/tls-db-std/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       - TRUSTSTORE_PATH=/tmp/tls-certs/truststore.p12
       - TRUSTSTORE_TYPE=PKCS12
       - TRUSTSTORE_PASSWORD=${TRUSTSTORE_PASSWORD}
-      - INITIAL_ADMIN_IDENTITY=CN=admin, OU=NIFI
+      - INITIAL_ADMIN_IDENTITY=admin
       - NIFI_REG_USE_PGDB=true
       - NIFI_REG_DB_FLOW_AUTHORIZERS=standard
       - dbUrl=jdbc:postgresql://postgresql:5432/postgres

--- a/.github/docker/tls-db/docker-compose.yaml
+++ b/.github/docker/tls-db/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       - TRUSTSTORE_PATH=/tmp/tls-certs/truststore.p12
       - TRUSTSTORE_TYPE=PKCS12
       - TRUSTSTORE_PASSWORD=${TRUSTSTORE_PASSWORD}
-      - INITIAL_ADMIN_IDENTITY=CN=admin, OU=NIFI
+      - INITIAL_ADMIN_IDENTITY=admin
       - NIFI_REG_USE_PGDB=true
       - dbUrl=jdbc:postgresql://postgresql:5432/postgres
       - dbUsername=postgres

--- a/.github/docker/tls/docker-compose.yaml
+++ b/.github/docker/tls/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       - TRUSTSTORE_PATH=/tmp/tls-certs/truststore.p12
       - TRUSTSTORE_TYPE=PKCS12
       - TRUSTSTORE_PASSWORD=${TRUSTSTORE_PASSWORD}
-      - INITIAL_ADMIN_IDENTITY=CN=admin, OU=NIFI
+      - INITIAL_ADMIN_IDENTITY=admin
     container_name: local-nifi-registry-tls
     hostname: nifi-registry
   consul:

--- a/nifi-scripts/pre_secure.sh
+++ b/nifi-scripts/pre_secure.sh
@@ -25,13 +25,13 @@ scripts_dir='/opt/nifi-registry/scripts'
 sed -i -r -e "s|^\#\s*(nifi\.registry\.security\.identity\.mapping\.pattern\.dn=)|\1|" "${NIFI_REGISTRY_HOME}"/conf/nifi-registry.properties
 sed -i -r -e "s|^\#\s*(nifi\.registry\.security\.identity\.mapping\.value\.dn=)|\1|" "${NIFI_REGISTRY_HOME}"/conf/nifi-registry.properties
 prop_replace 'nifi.registry.security.identity.mapping.pattern.dn' '\^\.\*EMAILADDRESS=\(\[\^,\]\*\)\.\*\$'
-prop_replace 'nifi.registry.security.identity.mapping.value.dn' "\$1"
+prop_replace 'nifi.registry.security.identity.mapping.value.dn' "\\\$1"
 
 {
     echo ""
     echo ""
-    echo "nifi.registry.security.identity.mapping.pattern.dn2=^CN=(.*?), .*$"
-    echo "nifi.registry.security.identity.mapping.value.dn2=$1"
+    echo "nifi.registry.security.identity.mapping.pattern.dn2=^CN=(.*?), .*\$"
+    echo "nifi.registry.security.identity.mapping.value.dn2=\$1"
 } >>"${NIFI_REGISTRY_HOME}"/conf/nifi-registry.properties
 
 

--- a/nifi-scripts/start.sh
+++ b/nifi-scripts/start.sh
@@ -34,15 +34,15 @@ prop_replace 'nifi.registry.web.http.port'      "${NIFI_REGISTRY_WEB_HTTP_PORT:-
 prop_replace 'nifi.registry.web.http.host'      "${NIFI_REGISTRY_WEB_HTTP_HOST:-$HOSTNAME}"
 
 
-if [ -n "${NIFI_REG_JVM_HEAP_INIT}" ] && [ "${NIFI_REG_JVM_HEAP_INIT}" != "${ENV_NIFI_REG_JVM_HEAP_INIT}" ]; then
+if [ -n "${NIFI_REG_JVM_HEAP_INIT}" ] && [ "${NIFI_REG_JVM_HEAP_INIT}" != "\${ENV_NIFI_REG_JVM_HEAP_INIT}" ]; then
     prop_replace 'java.arg.2'       "-Xms${NIFI_REG_JVM_HEAP_INIT}" "${NIFI_REGISTRY_HOME}"/conf/bootstrap.conf
 fi
 
-if [ -n "${NIFI_REG_JVM_HEAP_MAX}" ] && [ "${NIFI_REG_JVM_HEAP_MAX}" != "${ENV_NIFI_REG_JVM_HEAP_MAX}" ]; then
+if [ -n "${NIFI_REG_JVM_HEAP_MAX}" ] && [ "${NIFI_REG_JVM_HEAP_MAX}" != "\${ENV_NIFI_REG_JVM_HEAP_MAX}" ]; then
     prop_replace 'java.arg.3'       "-Xmx${NIFI_REG_JVM_HEAP_MAX}" "${NIFI_REGISTRY_HOME}"/conf/bootstrap.conf
 fi
 
-if [ -n "${NIFI_REG_XSS}" ] && [ "${NIFI_REG_XSS}" != "${ENV_NIFI_REG_XSS}" ]; then
+if [ -n "${NIFI_REG_XSS}" ] && [ "${NIFI_REG_XSS}" != "\${ENV_NIFI_REG_XSS}" ]; then
     {
         echo ""
         echo ""
@@ -61,7 +61,7 @@ if [ -n "${NIFI_DEBUG_NATIVE_MEMORY}" ]; then
 fi
 echo "" >> "${NIFI_REGISTRY_HOME}"/conf/bootstrap.conf
 
-if [ -n "${NIFI_REG_ADDITIONAL_JVM_ARGS}" ] && [ "${NIFI_REG_ADDITIONAL_JVM_ARGS}" != "${ENV_NIFI_REG_ADDITIONAL_JVM_ARGS}" ]; then
+if [ -n "${NIFI_REG_ADDITIONAL_JVM_ARGS}" ] && [ "${NIFI_REG_ADDITIONAL_JVM_ARGS}" != "\${ENV_NIFI_REG_ADDITIONAL_JVM_ARGS}" ]; then
     i=9
     read -r -a addJvmArgArr <<< "$NIFI_REG_ADDITIONAL_JVM_ARGS"
     for addJvmArg in "${addJvmArgArr[@]}"; do


### PR DESCRIPTION
Incorrect shellcheck fixes done in PR [fix: fixed shellcheck errors](https://github.com/Netcracker/qubership-nifi-registry/pull/9) may cause significant issue: identity mappings for users does not work due to wrong $ replacement, so identity for users from certificates will be DNs and they might not match with identities from OIDC, LDAP or other sources.