### PR TITLE
fix: change default web.https.application.protocols to http/1.1

### DIFF
--- a/qubership-nifi-registry-consul/qubership-nifi-registry-consul-util/src/main/resources/nifi_registry_default.properties
+++ b/qubership-nifi-registry-consul/qubership-nifi-registry-consul-util/src/main/resources/nifi_registry_default.properties
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # web properties #
-nifi.registry.web.https.application.protocols=h2 http/1.1
+nifi.registry.web.https.application.protocols=http/1.1
 nifi.registry.web.jetty.threads=200
 nifi.registry.web.should.send.server.version=true
 


### PR DESCRIPTION
Restore default nifi.registry.web.https.application.protocols to http/1.1, which was used in Apache NiFi 1.x version as default.
