### PR TITLE
fix(ci): skip sonar integration, if not properly configured

### DIFF
--- a/.github/workflows/maven-build.yaml
+++ b/.github/workflows/maven-build.yaml
@@ -94,7 +94,7 @@ jobs:
           gpg-private-key: ${{ secrets.gpg-private-key }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Run local maven build with sonar
-        if: ${{ !inputs.skip-sonar }}
+        if: ${{ !inputs.skip-sonar && vars.SONAR_HOST_URL }}
         run: >
           mvn --batch-mode package
           -Dgpg.skip=true
@@ -109,7 +109,7 @@ jobs:
           SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
       - name: Run local maven build w/o sonar
-        if: ${{ inputs.skip-sonar }}
+        if: ${{ inputs.skip-sonar || !vars.SONAR_HOST_URL }}
         run: >
           mvn --batch-mode package
         env:


### PR DESCRIPTION
Fixes maven-build.yaml workflow, so that it's not trying to run SonarCloud integration, if it's not configured, i.e. SONAR_HOST_URL is not set.
This change allows maven-build.yaml to function normally in forks without the need to configure full SonarCloud integration there.