### PR TITLE
fix: upgrade surefire-plugin to 3.5.3 to fix junit tests execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -224,10 +224,10 @@
                 <version>3.5.3</version>
                 <configuration>
                     <argLine>@{argLine} -Duser.timezone=UTC</argLine>
+                    <systemPropertyVariables>
+                        <api.version>1.44</api.version>
+                    </systemPropertyVariables>
                 </configuration>
-                <systemPropertyVariables>
-                    <api.version>1.44</api.version>
-                </systemPropertyVariables>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/qubership-nifi-registry-consul/pom.xml
+++ b/qubership-nifi-registry-consul/pom.xml
@@ -206,10 +206,10 @@
                 <version>3.5.3</version>
                 <configuration>
                     <argLine>@{argLine} -Duser.timezone=UTC</argLine>
+                    <systemPropertyVariables>
+                        <api.version>1.44</api.version>
+                    </systemPropertyVariables>
                 </configuration>
-                <systemPropertyVariables>
-                    <api.version>1.44</api.version>
-                </systemPropertyVariables>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
1. upgrade surefire-plugin to 3.5.3 to fix junit tests execution
2. add api.version to surefire plugin to avoid errors in unit tests