### PR TITLE
fix: fix flatten plugin configuration to remove extra parent references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
                 <version>${flatten-maven-plugin.version}</version>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
-                    <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                    <flattenMode>oss</flattenMode>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Fixes flatten plugin configuration to remove extra parent references. qubership-nifi-registry-consul-templates version 2.3.0  was published with non-existent parent reference.