### PR TITLE
fix: process only consul config sources in quarkus consul util

### DIFF
--- a/qubership-nifi-registry-quarkus-consul/qubership-nifi-registry-quarkus-consul-util/src/main/java/org/qubership/cloud/nifi/registry/quarkus/config/ConsulPropertiesProvider.java
+++ b/qubership-nifi-registry-quarkus-consul/qubership-nifi-registry-quarkus-consul-util/src/main/java/org/qubership/cloud/nifi/registry/quarkus/config/ConsulPropertiesProvider.java
@@ -1,5 +1,6 @@
 package org.qubership.cloud.nifi.registry.quarkus.config;
 
+import com.netcracker.cloud.consul.config.source.runtime.ConsulConfigSourceFactory;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.Config;
@@ -29,11 +30,16 @@ public class ConsulPropertiesProvider
 
         // Get all config sources from MicroProfile Config
         for (ConfigSource configSource : config.getConfigSources()) {
-            // Get all property names from each:
-            Set<String> allNames = configSource.getPropertyNames();
-            for (String name : allNames) {
-                if (name.toLowerCase().startsWith("logger.") || name.toLowerCase().startsWith("nifi.registry.")) {
-                    allPropertyNames.add(name);
+            String configSourceName = configSource.getName();
+            //config source name must start with ConsulConfigSourceFactory.BASE_CONFIG_SOURCE_NAME
+            if (configSourceName != null
+                    && configSourceName.startsWith(ConsulConfigSourceFactory.BASE_CONFIG_SOURCE_NAME)) {
+                // Get all property names from each:
+                Set<String> allNames = configSource.getPropertyNames();
+                for (String name : allNames) {
+                    if (name.toLowerCase().startsWith("logger.") || name.toLowerCase().startsWith("nifi.registry.")) {
+                        allPropertyNames.add(name);
+                    }
                 }
             }
         }

--- a/qubership-nifi-registry-quarkus-consul/qubership-nifi-registry-quarkus-consul-util/src/main/java/org/qubership/cloud/nifi/registry/quarkus/config/ConsulPropertiesProvider.java
+++ b/qubership-nifi-registry-quarkus-consul/qubership-nifi-registry-quarkus-consul-util/src/main/java/org/qubership/cloud/nifi/registry/quarkus/config/ConsulPropertiesProvider.java
@@ -32,8 +32,8 @@ public class ConsulPropertiesProvider
         for (ConfigSource configSource : config.getConfigSources()) {
             String configSourceName = configSource.getName();
             //config source name must start with ConsulConfigSourceFactory.BASE_CONFIG_SOURCE_NAME
-            if (configSourceName != null
-                    && configSourceName.startsWith(ConsulConfigSourceFactory.BASE_CONFIG_SOURCE_NAME)) {
+            if (configSourceName != null &&
+                    configSourceName.startsWith(ConsulConfigSourceFactory.BASE_CONFIG_SOURCE_NAME)) {
                 // Get all property names from each:
                 Set<String> allNames = configSource.getPropertyNames();
                 for (String name : allNames) {

--- a/qubership-nifi-registry-quarkus-consul/qubership-nifi-registry-quarkus-consul-util/src/test/java/org/qubership/cloud/nifi/registry/quarkus/config/PropertiesManagerTest.java
+++ b/qubership-nifi-registry-quarkus-consul/qubership-nifi-registry-quarkus-consul-util/src/test/java/org/qubership/cloud/nifi/registry/quarkus/config/PropertiesManagerTest.java
@@ -2,6 +2,7 @@ package org.qubership.cloud.nifi.registry.quarkus.config;
 
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 @QuarkusTest
 @QuarkusTestResource(ConsulTestResource.class)
+@TestProfile(PropertiesManagerTestProfile.class)
 class PropertiesManagerTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(PropertiesManagerTest.class);
@@ -109,6 +111,14 @@ class PropertiesManagerTest {
             Assertions.assertEquals("10 secs",
                     nifiRegistryProps.getProperty("nifi.registry.security.user.oidc.connect.timeout"),
                     "Consul property without default should be loaded");
+            Assertions.assertFalse(nifiRegistryProps.containsKey("NIFI_REGISTRY_HOME"),
+                    "Env variable NIFI_REGISTRY_HOME should not be loaded");
+            Assertions.assertFalse(nifiRegistryProps.containsKey("nifi.home"),
+                    "Env variable nifi.registry.home should not be loaded");
+            Assertions.assertFalse(nifiRegistryProps.containsKey("nifi.registry.env.prop1"),
+                    "Env variable nifi.registry.env.prop1 should not be loaded");
+            Assertions.assertFalse(nifiRegistryProps.containsKey("nifi.registry.env.prop2"),
+                    "Env variable nifi.registry.env.prop2 should not be loaded");
         } catch (IOException e) {
             Assertions.fail("Failed to read nifi-registry.properties", e);
         }

--- a/qubership-nifi-registry-quarkus-consul/qubership-nifi-registry-quarkus-consul-util/src/test/java/org/qubership/cloud/nifi/registry/quarkus/config/PropertiesManagerTestProfile.java
+++ b/qubership-nifi-registry-quarkus-consul/qubership-nifi-registry-quarkus-consul-util/src/test/java/org/qubership/cloud/nifi/registry/quarkus/config/PropertiesManagerTestProfile.java
@@ -1,0 +1,23 @@
+package org.qubership.cloud.nifi.registry.quarkus.config;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+import java.util.Map;
+
+public class PropertiesManagerTestProfile
+        implements QuarkusTestProfile {
+
+    public PropertiesManagerTestProfile () {
+        //default constructor
+    }
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "NIFI_REGISTRY_HOME", "./test-location",
+                "nifi.registry.home", "./test-location2",
+                "nifi.registry.env.prop1", "1",
+                "nifi.registry.env.prop2", "2"
+        );
+    }
+}

--- a/qubership-nifi-registry-quarkus-consul/qubership-nifi-registry-quarkus-consul-util/src/test/java/org/qubership/cloud/nifi/registry/quarkus/config/PropertiesManagerTestProfile.java
+++ b/qubership-nifi-registry-quarkus-consul/qubership-nifi-registry-quarkus-consul-util/src/test/java/org/qubership/cloud/nifi/registry/quarkus/config/PropertiesManagerTestProfile.java
@@ -7,7 +7,7 @@ import java.util.Map;
 public class PropertiesManagerTestProfile
         implements QuarkusTestProfile {
 
-    public PropertiesManagerTestProfile () {
+    public PropertiesManagerTestProfile() {
         //default constructor
     }
 


### PR DESCRIPTION
Adds missing filter for config sources to be processed in qubership-nifi-registry-quarkus-consul-util. Only Consul-related config sources must be processed similar to Spring-based qubership-nifi-registry-consul-util.