### PR TITLE
feat: support file paths for sensitive env variables

### DIFF
--- a/.github/docker/oidc/docker-compose.yaml
+++ b/.github/docker/oidc/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
     volumes:
       - tls-cert-reg:/tmp/tls-certs
       - tls-cert-ca:/tmp/cert
+      - tls-cert-pwd:/tmp/cert-pwd
     ports:
       - 127.0.0.1:18080:18080
     environment:
@@ -36,10 +37,11 @@ services:
       - NIFI_REGISTRY_WEB_HTTP_HOST=0.0.0.0
       - KEYSTORE_PATH=/tmp/tls-certs/keystore.p12
       - KEYSTORE_TYPE=PKCS12
-      - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD_NIFI_REG}
       - TRUSTSTORE_PATH=/tmp/tls-certs/truststore.p12
       - TRUSTSTORE_TYPE=PKCS12
-      - TRUSTSTORE_PASSWORD=${TRUSTSTORE_PASSWORD}
+      - NIFI_REG_KEY_PASSWORD_PATH=/tmp/cert-pwd/keystore-nifi-reg.pass
+      - NIFI_REG_KEYSTORE_PASSWORD_PATH=/tmp/cert-pwd/keystore-nifi-reg.pass
+      - NIFI_REG_TRUSTSTORE_PASSWORD_PATH=/tmp/cert-pwd/truststore.pass
       - INITIAL_ADMIN_IDENTITY=admin
       - NIFI_REG_USE_PGDB=true
       - NIFI_REG_DB_URL=jdbc:postgresql://postgresql:5432/postgres?sslResponseTimeout=5000&ssl=false
@@ -154,6 +156,12 @@ volumes:
       o: bind
       type: none
       device: $BASE_DIR/temp-vol/tls-cert/ca/
+  tls-cert-pwd:
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: $BASE_DIR/temp-vol/tls-cert/pwd/
   pg-db:
     driver: local
     driver_opts:

--- a/.github/docker/tls-quarkus/docker-compose.yaml
+++ b/.github/docker/tls-quarkus/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
       - nifi-reg-db:/opt/nifi-registry/nifi-registry-current/database
       - nifi-reg-flow:/opt/nifi-registry/nifi-registry-current/flow_storage
       - tls-cert-reg:/tmp/tls-certs
+      - tls-cert-pwd:/tmp/cert-pwd
     ports:
       - 127.0.0.1:18080:18080
     environment:
@@ -29,10 +30,11 @@ services:
       - NIFI_REGISTRY_WEB_HTTP_HOST=0.0.0.0
       - KEYSTORE_PATH=/tmp/tls-certs/keystore.p12
       - KEYSTORE_TYPE=PKCS12
-      - KEYSTORE_PASSWORD=${KEYSTORE_PASSWORD_NIFI_REG}
       - TRUSTSTORE_PATH=/tmp/tls-certs/truststore.p12
       - TRUSTSTORE_TYPE=PKCS12
-      - TRUSTSTORE_PASSWORD=${TRUSTSTORE_PASSWORD}
+      - NIFI_REG_KEY_PASSWORD_PATH=/tmp/cert-pwd/keystore-nifi-reg.pass
+      - NIFI_REG_KEYSTORE_PASSWORD_PATH=/tmp/cert-pwd/keystore-nifi-reg.pass
+      - NIFI_REG_TRUSTSTORE_PASSWORD_PATH=/tmp/cert-pwd/truststore.pass
       - INITIAL_ADMIN_IDENTITY=admin
       - CONSUL_ENABLED=true
       #default NIFI_CONSUL_INT_FRAMEWORK = quarkus
@@ -63,6 +65,12 @@ volumes:
       o: bind
       type: none
       device: $BASE_DIR/temp-vol/tls-cert/nifi-registry/
+  tls-cert-pwd:
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: $BASE_DIR/temp-vol/tls-cert/pwd/
   nifi-reg-db:
     driver: local
     driver_opts:

--- a/.github/workflows/sh/nifi-gen-certs.sh
+++ b/.github/workflows/sh/nifi-gen-certs.sh
@@ -40,6 +40,13 @@ generate_nifi_certs(){
     #make files available to all users:
     chmod -R 777 /tmp/tls-certs/nifi-registry
     chmod -R 777 /tmp/tls-certs/nifi
+    #duplicate key/keystore passwords to file path for tests:
+    mkdir -p /tmp/tls-certs/pwd
+    chmod 777 /tmp/tls-certs/pwd
+    echo "$KEYSTORE_PASSWORD_NIFI" > /tmp/tls-certs/pwd/keystore-nifi.pass
+    echo "$KEYSTORE_PASSWORD_NIFI_REG" > /tmp/tls-certs/pwd/keystore-nifi-reg.pass
+    echo "$TRUSTSTORE_PASSWORD" > /tmp/tls-certs/pwd/truststore.pass
+    chmod -R 777 /tmp/tls-certs/pwd
     return 0;
 }
 

--- a/.github/workflows/sh/nifi-lib.sh
+++ b/.github/workflows/sh/nifi-lib.sh
@@ -294,6 +294,7 @@ setup_env_before_tests() {
     fi
     mkdir -p ./temp-vol/tls-cert/
     mkdir -p ./temp-vol/tls-cert/nifi-registry/
+    mkdir -p ./temp-vol/tls-cert/pwd/
     if [[ "$runMode" == "oidc" ]]; then
         mkdir -p ./temp-vol/tls-cert/ca/
     fi

--- a/docs/administrator-guide.md
+++ b/docs/administrator-guide.md
@@ -16,9 +16,12 @@ The table below describes environment variables supported by qubership-nifi-regi
 | OIDC_DISCOVERY_URL_NEW                           | Y (if AUTH = oidc)                |         | The Discovery Configuration URL for the OpenID Connect Provider                                                                                                                                                                                        |
 | OIDC_CLIENT_ID                                   | Y (if AUTH = oidc)                |         | The Client ID for NiFi registered with the OpenID Connect Provider                                                                                                                                                                                     |
 | OIDC_CLIENT_SECRET                               | Y (if AUTH = oidc)                |         | The Client Secret for NiFi registered with the OpenID Connect Provider                                                                                                                                                                                 |
-| KEY_PASSWORD                                     | Y (if AUTH = oidc or tls or ldap) |         | The key password for secret key stored in the keystore. May contain any printable characters except for `\` (backslash).                                                                                                                               |
-| KEYSTORE_PASSWORD                                | Y (if AUTH = oidc or tls or ldap) |         | The keystore password for the keystore. May contain any printable characters except for `\` (backslash).                                                                                                                                               |
-| TRUSTSTORE_PASSWORD                              | Y (if AUTH = oidc or tls or ldap) |         | The truststore password. May contain any printable characters except for `\` (backslash).                                                                                                                                                              |
+| KEY_PASSWORD                                     | N                                 |         | The key password for secret key stored in the keystore. May contain any printable characters except for `\` (backslash). Either `KEY_PASSWORD` or `NIFI_REG_KEY_PASSWORD_PATH` must be set, if `AUTH` = oidc or tls or ldap.                           |
+| NIFI_REG_KEY_PASSWORD_PATH                       | N                                 |         | Path to the file with the key password for secret key stored in the keystore. Used only if `KEY_PASSWORD` is not set. Supported for `AUTH` = oidc or tls.                                                                                              |
+| KEYSTORE_PASSWORD                                | N                                 |         | The keystore password for the keystore. May contain any printable characters except for `\` (backslash). Either `KEYSTORE_PASSWORD` or `NIFI_REG_KEYSTORE_PASSWORD_PATH` must be set, if `AUTH` = oidc or tls or ldap.                                 |
+| NIFI_REG_KEYSTORE_PASSWORD_PATH                  | N                                 |         | Path to the file with the keystore password for the keystore. Used only if `KEYSTORE_PASSWORD` is not set. Supported for `AUTH` = oidc or tls.                                                                                                         |
+| TRUSTSTORE_PASSWORD                              | N                                 |         | The truststore password. May contain any printable characters except for `\` (backslash). Either `TRUSTSTORE_PASSWORD` or `NIFI_REG_TRUSTSTORE_PASSWORD_PATH` must be set, if `AUTH` = oidc or tls or ldap.                                            |
+| NIFI_REG_TRUSTSTORE_PASSWORD_PATH                | N                                 |         | Path to the file with the truststore password. Used only if `TRUSTSTORE_PASSWORD` is not set. Supported for `AUTH` = oidc or tls.                                                                                                                      |
 | NIFI_REGISTRY_WEB_HTTP_PORT                      | N                                 | 18080   | The HTTP port.                                                                                                                                                                                                                                         |
 | NIFI_REGISTRY_WEB_HTTPS_PORT                     | N                                 |         | The HTTPS host. It is blank by default.                                                                                                                                                                                                                |
 | NIFI_REGISTRY_WEB_HTTP_HOST                      | N                                 |         | The HTTP host. It is blank by default.                                                                                                                                                                                                                 |
@@ -43,7 +46,6 @@ The table below describes environment variables supported by qubership-nifi-regi
 | NIFI_REGISTRY_DB_DEBUG_SQL                       | N                                 | false   | Whether or not enable debug logging for SQL statements. Defines value for `nifi.registry.db.sql.debug` property.                                                                                                                                       |
 | NIFI_REGISTRY_SECURITY_USER_OIDC_CONNECT_TIMEOUT | N                                 | 5 secs  | Socket Connect timeout when communicating with the OpenID Connect Provider. Defines value for `nifi.registry.security.user.oidc.connect.timeout` property.                                                                                             |
 | NIFI_REGISTRY_SECURITY_USER_OIDC_READ_TIMEOUT    | N                                 | 5 secs  | Socket Read timeout when communicating with the OpenID Connect Provider. Defines value for `nifi.registry.security.user.oidc.read.timeout` property.                                                                                                   |
-
 
 ## Extension points
 
@@ -72,10 +74,14 @@ The table below provides a list of volumes and directories and their description
 | TLS certificates           | Directory | /tmp/tls-certs                                           | Contains TLS keystore (keystore.p12) and truststore (truststore.p12). Required for startup with AUTH = oidc, tls, ldap.                                                  |
 | Configuration data         | Directory | /opt/nifi-registry/nifi-registry-current/persistent_data | Contains metadata database and flow storage, if NIFI_REG_USE_PGDB != `true`.                                                                                             |
 | Cached providers extension | Directory | /opt/nifi-registry/nifi-registry-current/ext-cached      | Extension for cached access policy and user group providers. See also environment property `NIFI_REG_DB_FLOW_AUTHORIZERS` and section below dedicated to this extension. |
+| Key password               | File      | `$NIFI_REG_KEY_PASSWORD_PATH`                            | Contains the key password for secret key stored in the keystore. File-based alternative to `KEY_PASSWORD`. Used only if `KEY_PASSWORD` is not set.                       |
+| Keystore password          | File      | `$NIFI_REG_KEYSTORE_PASSWORD_PATH`                       | Contains the keystore password. File-based alternative to `KEYSTORE_PASSWORD`. Used only if `KEYSTORE_PASSWORD` is not set.                                              |
+| Truststore password        | File      | `$NIFI_REG_TRUSTSTORE_PASSWORD_PATH`                     | Contains the truststore password. File-based alternative to `TRUSTSTORE_PASSWORD`. Used only if `TRUSTSTORE_PASSWORD` is not set.                                        |
 
 ## Changing logging levels
 
 You can modify logging levels by:
+
 1. Setting `ROOT_LOG_LEVEL` environment variable. Be mindful that this variable allows you to set only root logging level;
 2. Setting logging level for specific package in Consul. Consul property name must start with "logger." followed by package name. Value should be one of logging level supported by Logback: ALL, TRACE, DEBUG, INFO, WARN, ERROR, OFF. Property should be located in one of two locations:
     1. `config/${NAMESPACE}/application`, where `NAMESPACE` is a value of `NAMESPACE` environment variable, or value = `local`, if not set.
@@ -84,16 +90,19 @@ You can modify logging levels by:
 ## Changing NiFi Registry configuration properties
 
 NiFi Registry configuration properties could be set up in Consul:
+
 1. Property name must start with `nifi.registry.`
 2. Property should be located in one of two locations:
     1. `config/${NAMESPACE}/application`, where `NAMESPACE` is a value of `NAMESPACE` environment variable, or value = `local`, if not set.
     2. `config/${NAMESPACE}/${MICROSERVICE_NAME}` or `config/${NAMESPACE}/qubership-nifi-registry`, if `MICROSERVICE_NAME` not set.
 
 To change NiFi Registry properties:
+
 1. Change the NiFi Registry properties in Consul as per your requirements.
 2. Restart qubership-nifi-registry container.
 
 The list of properties that can be configured via Consul:
+
 - nifi.registry.web.https.application.protocols
 - nifi.registry.web.jetty.threads
 - nifi.registry.web.should.send.server.version
@@ -115,6 +124,7 @@ The detailed description of all supported NiFi Registry properties is available 
 ## Migration from file storage
 
 To migrate data from file-based storage to PostgreSQL DB one needs to:
+
 1. enable DB usage for storage in environment variables: set NIFI_REG_USE_PGDB = `true`
 2. set up DB connection details:
    - either via environment variables (NIFI_REG_DB_URL, NIFI_REG_DB_USERNAME, NIFI_REG_DB_PASSWORD)
@@ -131,6 +141,7 @@ This extension contains libraries for PostgreSQL DB-based access policy (CachedD
 Functionality of these providers is identical to standard DatabaseAccessPolicyProvider and DatabaseUserGroupProvider.
 Configuration parameters are the same as for standard DatabaseAccessPolicyProvider and DatabaseUserGroupProvider.
 The differences are:
+
 1. only PostgreSQL Database is supported
 2. cached providers load in-memory cache for all entities, if bulk method (e.g. getPolicies or getUsers) is called, or only accessed entities (if single gets are used).
 3. cache is hold until the next restart. The assumption is that all changes to DB are done via provider, so it can properly update the cache.

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -3,6 +3,7 @@
 qubership-nifi-registry service can be started in docker (or compatible) container runtime with support of `docker compose` command.
 
 Sections below describe typical startup configurations:
+
 1. plain - service without any authentication with plain (HTTP) communications and file-based storage
 2. tls - service with mTLS authentication with encrypted (HTTPS) communications and file-based storage
 3. db - service with mTLS authentication, encrypted (HTTPS) communications and PostgreSQL storage
@@ -13,11 +14,12 @@ Sections below describe typical startup configurations:
 ### Plain
 
 Execute the following steps, to run service:
+
 1. Set up environment parameters [`docker.env`](../dev/plain/docker.env)
 
-| Parameter | Required | Default | Description                                                                                                                                                                                                                              |
-|-----------|----------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| BASE_DIR  | Y        | .       | Defines directory, where local volumes will be located. Subdirectories include:<ul><li>temp-vol/nifi-reg/database/ - for storing metadata (buckets, flows)</li><li>temp-vol/nifi-reg/flow-storage/ - for storing flow versions</li></ul> |
+   | Parameter | Required | Default | Description                                                                                                                                                                                                               |
+   |-----------|----------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+   | BASE_DIR  | Y        | .       | Defines directory, where local volumes will be located. Subdirectories include:<br>- temp-vol/nifi-reg/database/ - for storing metadata (buckets, flows)<br>- temp-vol/nifi-reg/flow-storage/ - for storing flow versions |
 
 2. Change image in docker compose [`docker-compose.yaml`](../dev/plain/docker-compose.yaml), if needed. By default, `ghcr.io/netcracker/nifi-registry:latest` is used
 3. Start docker compose
@@ -29,14 +31,15 @@ docker compose -f dev/plain/docker-compose.yaml --env-file dev/plain/docker.env 
 ### TLS
 
 Execute the following steps, to run service:
+
 1. Set up environment parameters [`docker.env`](../dev/tls/docker.env)
 
-| Parameter           | Required | Default | Description                                                                                                                                                                                                                                                                                |
-|---------------------|----------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| BASE_DIR            | Y        | .       | Defines directory, where local volumes will be located. Subdirectories include:<ul><li>temp-vol/nifi-reg/database/ - for storing metadata (buckets, flows)</li><li>temp-vol/nifi-reg/flow-storage/ - for storing flow versions</li><li>temp-vol/tls-cert/ - for TLS certificates</li></ul> |
-| GIT_REPO_DIR        | Y        | .       | Defines directory, where qubership-nifi-registry repository is located locally.                                                                                                                                                                                                            |
-| TRUSTSTORE_PASSWORD | Y        |         | Defines password for keystore with trusted certificates. It'll be created during the first run.                                                                                                                                                                                            |
-| KEYSTORE_PASSWORD   | Y        |         | Defines password for keystore with server certificates. It'll be created during the first run.                                                                                                                                                                                             |
+   | Parameter           | Required | Default | Description                                                                                                                                                                                                                                                              |
+   |---------------------|----------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+   | BASE_DIR            | Y        | .       | Defines directory, where local volumes will be located. Subdirectories include:<br>- temp-vol/nifi-reg/database/ - for storing metadata (buckets, flows)<br>- temp-vol/nifi-reg/flow-storage/ - for storing flow versions<br>- temp-vol/tls-cert/ - for TLS certificates |
+   | GIT_REPO_DIR        | Y        | .       | Defines directory, where qubership-nifi-registry repository is located locally.                                                                                                                                                                                          |
+   | TRUSTSTORE_PASSWORD | Y        |         | Defines password for keystore with trusted certificates. It'll be created during the first run.                                                                                                                                                                          |
+   | KEYSTORE_PASSWORD   | Y        |         | Defines password for keystore with server certificates. It'll be created during the first run.                                                                                                                                                                           |
 
 2. Change image in docker compose [`docker-compose.yaml`](../dev/tls/docker-compose.yaml), if needed. By default, `ghcr.io/netcracker/nifi-registry:latest` is used
 3. Start docker compose
@@ -48,22 +51,25 @@ docker compose -f dev/tls/docker-compose.yaml --env-file dev/tls/docker.env up -
 ### DB
 
 Starts the following services:
+
 1. qubership-nifi-registry
 2. postgresql.
 
 As well as one auxiliary container:
+
 1. nifi-toolkit - to generate TLS certificates using Apache NiFi Toolkit.
 
 Execute the following steps, to run service:
+
 1. Set up environment parameters [`docker.env`](../dev/tls-db/docker.env)
 
-| Parameter           | Required | Default | Description                                                                                                                                                                                                                            |
-|---------------------|----------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| BASE_DIR            | Y        | .       | Defines directory, where local volumes will be located. Subdirectories include:<ul><li>temp-vol/pg-db/ - for storing PostgreSQL database with qubership-nifi-registry data</li><li>temp-vol/tls-cert/ - for TLS certificates</li></ul> |
-| GIT_REPO_DIR        | Y        | .       | Defines directory, where qubership-nifi-registry repository is located locally.                                                                                                                                                        |
-| TRUSTSTORE_PASSWORD | Y        |         | Defines password for keystore with trusted certificates. It'll be created during the first run.                                                                                                                                        |
-| KEYSTORE_PASSWORD   | Y        |         | Defines password for keystore with server certificates. It'll be created during the first run.                                                                                                                                         |
-| DB_PASSWORD         | Y        |         | Defines password for PostgreSQL database.                                                                                                                                                                                              |
+   | Parameter           | Required | Default | Description                                                                                                                                                                                                             |
+   |---------------------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+   | BASE_DIR            | Y        | .       | Defines directory, where local volumes will be located. Subdirectories include:<br>- temp-vol/pg-db/ - for storing PostgreSQL database with qubership-nifi-registry data<br>- temp-vol/tls-cert/ - for TLS certificates |
+   | GIT_REPO_DIR        | Y        | .       | Defines directory, where qubership-nifi-registry repository is located locally.                                                                                                                                         |
+   | TRUSTSTORE_PASSWORD | Y        |         | Defines password for keystore with trusted certificates. It'll be created during the first run.                                                                                                                         |
+   | KEYSTORE_PASSWORD   | Y        |         | Defines password for keystore with server certificates. It'll be created during the first run.                                                                                                                          |
+   | DB_PASSWORD         | Y        |         | Defines password for PostgreSQL database.                                                                                                                                                                               |
 
 2. Start docker compose
 
@@ -74,25 +80,28 @@ docker compose -f dev/tls-db/docker-compose.yaml --env-file dev/tls-db/docker.en
 ### OIDC
 
 Starts the following services:
+
 1. qubership-nifi-registry
 2. postgresql
 3. keycloak.
 
 As well as two auxiliary containers:
+
 1. nifi-toolkit - to generate TLS certificates using Apache NiFi Toolkit
 2. postgresql-init - to create keycloak database.
 
 Execute the following steps, to run service:
+
 1. Set up environment parameters [`docker.env`](../dev/oidc/docker.env)
 
-| Parameter               | Required | Default | Description                                                                                                                                                                                                                            |
-|-------------------------|----------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| BASE_DIR                | Y        | .       | Defines directory, where local volumes will be located. Subdirectories include:<ul><li>temp-vol/pg-db/ - for storing PostgreSQL database with qubership-nifi-registry data</li><li>temp-vol/tls-cert/ - for TLS certificates</li></ul> |
-| GIT_REPO_DIR            | Y        | .       | Defines directory, where qubership-nifi-registry repository is located locally.                                                                                                                                                        |
-| TRUSTSTORE_PASSWORD     | Y        |         | Defines password for keystore with trusted certificates. It'll be created during the first run.                                                                                                                                        |
-| KEYSTORE_PASSWORD       | Y        |         | Defines password for keystore with server certificates. It'll be created during the first run.                                                                                                                                         |
-| DB_PASSWORD             | Y        |         | Defines password for postgres user in local PostgreSQL database.                                                                                                                                                                       |
-| KEYCLOAK_ADMIN_PASSWORD | Y        |         | Defines password for admin user in local keycloak instance.                                                                                                                                                                            |
+   | Parameter               | Required | Default | Description                                                                                                                                                                                                             |
+   |-------------------------|----------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+   | BASE_DIR                | Y        | .       | Defines directory, where local volumes will be located. Subdirectories include:<br>- temp-vol/pg-db/ - for storing PostgreSQL database with qubership-nifi-registry data<br>- temp-vol/tls-cert/ - for TLS certificates |
+   | GIT_REPO_DIR            | Y        | .       | Defines directory, where qubership-nifi-registry repository is located locally.                                                                                                                                         |
+   | TRUSTSTORE_PASSWORD     | Y        |         | Defines password for keystore with trusted certificates. It'll be created during the first run.                                                                                                                         |
+   | KEYSTORE_PASSWORD       | Y        |         | Defines password for keystore with server certificates. It'll be created during the first run.                                                                                                                          |
+   | DB_PASSWORD             | Y        |         | Defines password for postgres user in local PostgreSQL database.                                                                                                                                                        |
+   | KEYCLOAK_ADMIN_PASSWORD | Y        |         | Defines password for admin user in local keycloak instance.                                                                                                                                                             |
 
 2. Start docker compose
 

--- a/docs/installation-guide.md
+++ b/docs/installation-guide.md
@@ -1,6 +1,6 @@
 # Installation Guide
 
-qubership-nifi-registry service can be started in docker (or compatible) container runtime with support of `docker compose` command.
+qubership-nifi-registry service can be started in Docker (or compatible) container runtime with support of `docker compose` command.
 
 Sections below describe typical startup configurations:
 
@@ -21,8 +21,8 @@ Execute the following steps, to run service:
    |-----------|----------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
    | BASE_DIR  | Y        | .       | Defines directory, where local volumes will be located. Subdirectories include:<br>- temp-vol/nifi-reg/database/ - for storing metadata (buckets, flows)<br>- temp-vol/nifi-reg/flow-storage/ - for storing flow versions |
 
-2. Change image in docker compose [`docker-compose.yaml`](../dev/plain/docker-compose.yaml), if needed. By default, `ghcr.io/netcracker/nifi-registry:latest` is used
-3. Start docker compose
+2. Change image in Docker Compose [`docker-compose.yaml`](../dev/plain/docker-compose.yaml), if needed. By default, `ghcr.io/netcracker/nifi-registry:latest` is used
+3. Start Docker Compose
 
 ```shell
 docker compose -f dev/plain/docker-compose.yaml --env-file dev/plain/docker.env up -d
@@ -41,8 +41,8 @@ Execute the following steps, to run service:
    | TRUSTSTORE_PASSWORD | Y        |         | Defines password for keystore with trusted certificates. It'll be created during the first run.                                                                                                                                                                          |
    | KEYSTORE_PASSWORD   | Y        |         | Defines password for keystore with server certificates. It'll be created during the first run.                                                                                                                                                                           |
 
-2. Change image in docker compose [`docker-compose.yaml`](../dev/tls/docker-compose.yaml), if needed. By default, `ghcr.io/netcracker/nifi-registry:latest` is used
-3. Start docker compose
+2. Change image in Docker Compose [`docker-compose.yaml`](../dev/tls/docker-compose.yaml), if needed. By default, `ghcr.io/netcracker/nifi-registry:latest` is used
+3. Start Docker Compose
 
 ```shell
 docker compose -f dev/tls/docker-compose.yaml --env-file dev/tls/docker.env up -d
@@ -53,7 +53,7 @@ docker compose -f dev/tls/docker-compose.yaml --env-file dev/tls/docker.env up -
 Starts the following services:
 
 1. qubership-nifi-registry
-2. postgresql.
+2. PostgreSQL.
 
 As well as one auxiliary container:
 
@@ -71,7 +71,7 @@ Execute the following steps, to run service:
    | KEYSTORE_PASSWORD   | Y        |         | Defines password for keystore with server certificates. It'll be created during the first run.                                                                                                                          |
    | DB_PASSWORD         | Y        |         | Defines password for PostgreSQL database.                                                                                                                                                                               |
 
-2. Start docker compose
+2. Start Docker Compose
 
 ```shell
 docker compose -f dev/tls-db/docker-compose.yaml --env-file dev/tls-db/docker.env up -d
@@ -82,7 +82,7 @@ docker compose -f dev/tls-db/docker-compose.yaml --env-file dev/tls-db/docker.en
 Starts the following services:
 
 1. qubership-nifi-registry
-2. postgresql
+2. PostgreSQL
 3. keycloak.
 
 As well as two auxiliary containers:
@@ -103,7 +103,7 @@ Execute the following steps, to run service:
    | DB_PASSWORD             | Y        |         | Defines password for postgres user in local PostgreSQL database.                                                                                                                                                        |
    | KEYCLOAK_ADMIN_PASSWORD | Y        |         | Defines password for admin user in local keycloak instance.                                                                                                                                                             |
 
-2. Start docker compose
+2. Start Docker Compose
 
 ```shell
 docker compose -f dev/oidc/docker-compose.yaml --env-file dev/oidc/docker.env up -d

--- a/nifi-scripts/pre_secure.sh
+++ b/nifi-scripts/pre_secure.sh
@@ -46,6 +46,35 @@ export TRUSTSTORE_PATH="/tmp/tls-certs/truststore.p12"
 export TRUSTSTORE_TYPE="PKCS12"
 export KEYSTORE_PATH="/tmp/tls-certs/keystore.p12"
 export KEYSTORE_TYPE="PKCS12"
+
+### key password
+if [ -z "$KEY_PASSWORD" ] && [ -n "$NIFI_REG_KEY_PASSWORD_PATH" ]; then
+    if [ -f "$NIFI_REG_KEY_PASSWORD_PATH" ]; then
+        info "Found key password file $NIFI_REG_KEY_PASSWORD_PATH, fetching data"
+        KEY_PASSWORD=$(cat "$NIFI_REG_KEY_PASSWORD_PATH")
+    else
+        warn "Key password file $NIFI_REG_KEY_PASSWORD_PATH does not exist"
+    fi
+fi
+### keystore password
+if [ -z "$KEYSTORE_PASSWORD" ] && [ -n "$NIFI_REG_KEYSTORE_PASSWORD_PATH" ]; then
+    if [ -f "$NIFI_REG_KEYSTORE_PASSWORD_PATH" ]; then
+        info "Found keystore password file $NIFI_REG_KEYSTORE_PASSWORD_PATH, fetching data"
+        KEYSTORE_PASSWORD=$(cat "$NIFI_REG_KEYSTORE_PASSWORD_PATH")
+    else
+        warn "Keystore password file $NIFI_REG_KEYSTORE_PASSWORD_PATH does not exist"
+    fi
+fi
+### truststore password
+if [ -z "$TRUSTSTORE_PASSWORD" ] && [ -n "$NIFI_REG_TRUSTSTORE_PASSWORD_PATH" ]; then
+    if [ -f "$NIFI_REG_TRUSTSTORE_PASSWORD_PATH" ]; then
+        info "Found truststore password file $NIFI_REG_TRUSTSTORE_PASSWORD_PATH, fetching data"
+        TRUSTSTORE_PASSWORD=$(cat "$NIFI_REG_TRUSTSTORE_PASSWORD_PATH")
+    else
+        warn "Truststore password file $NIFI_REG_TRUSTSTORE_PASSWORD_PATH does not exist"
+    fi
+fi
+
 TRUSTSTORE_PASSWORD=$(echo "$TRUSTSTORE_PASSWORD" | sed -e "s|&|\\\\&|g")
 export TRUSTSTORE_PASSWORD
 KEYSTORE_PASSWORD=$(echo "$KEYSTORE_PASSWORD" | sed -e "s|&|\\\\&|g")


### PR DESCRIPTION
* Adds ability to provide sensitive variables (KEY_PASSWORD, KEYSTORE_PASSWORD, TRUSTSTORE_PASSWORD) via files.

* New functionality works as a fallback: only if envirorment variable is not set, file path will be used. 

* Applies only for AUTH = oidc or tls.